### PR TITLE
Fix : MPpotionLarge 아이템 획득 버그 및 Inventory 데이터 복구 문제 해결

### DIFF
--- a/.idea/.idea.JangPoong/.idea/workspace.xml
+++ b/.idea/.idea.JangPoong/.idea/workspace.xml
@@ -6,13 +6,8 @@
   <component name="ChangeListManager">
     <list default="true" id="8d60103f-3d9b-4716-9d1c-3d51d042b424" name="변경" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/.idea.JangPoong/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.JangPoong/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Resources/Prefabs/UI/Scene/UI_Game_Root.prefab" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Resources/Prefabs/UI/Scene/UI_Game_Root.prefab" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scenes/1-1 tutorial.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/1-1 tutorial.unity" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Items/ItemBase.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Items/ItemBase.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Data/InventoryData.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Data/InventoryData.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Assets/Scripts/Managers/InventoryManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Managers/InventoryManager.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Monsters/Monster.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Monsters/Monster.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/UI/Buttons/UI_GameOverButtons.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/UI/Buttons/UI_GameOverButtons.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/UI/Inventory/InventoryUI.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/UI/Inventory/InventoryUI.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/.idea/.idea.JangPoong/.idea/workspace.xml
+++ b/.idea/.idea.JangPoong/.idea/workspace.xml
@@ -5,22 +5,13 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="8d60103f-3d9b-4716-9d1c-3d51d042b424" name="변경" comment="">
-      <change afterPath="$PROJECT_DIR$/Assets/Scripts/Data/InventoryData.cs" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Assets/Scripts/Data/InventoryData.cs.meta" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Assets/Scripts/ETC/DictionaryEnumKeyConverter.cs" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Assets/Scripts/ETC/DictionaryEnumKeyConverter.cs.meta" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/.idea.JangPoong/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.JangPoong/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Resources/Data/InitData/Inventory.json" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Resources/Data/InitData/Inventory.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Common/Define.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Common/Define.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Data/SettingData.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Data/SettingData.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Items/Destination.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Items/Destination.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Managers/DataManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Managers/DataManager.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Managers/GameManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Managers/GameManager.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Resources/Prefabs/UI/Scene/UI_Game_Root.prefab" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Resources/Prefabs/UI/Scene/UI_Game_Root.prefab" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scenes/1-1 tutorial.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/1-1 tutorial.unity" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Items/ItemBase.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Items/ItemBase.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Assets/Scripts/Managers/InventoryManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Managers/InventoryManager.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Managers/KeyBindingManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Managers/KeyBindingManager.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Managers/Managers.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Managers/Managers.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Managers/SoundManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Managers/SoundManager.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Sounds/AudioMixerController.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Sounds/AudioMixerController.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Monsters/Monster.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Monsters/Monster.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/UI/Buttons/UI_GameOverButtons.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/UI/Buttons/UI_GameOverButtons.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Assets/Scripts/UI/Inventory/InventoryUI.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/UI/Inventory/InventoryUI.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />

--- a/Assets/Resources/Prefabs/Items/Items_Player/MPpotionLargePrefab.prefab
+++ b/Assets/Resources/Prefabs/Items/Items_Player/MPpotionLargePrefab.prefab
@@ -164,7 +164,7 @@ CircleCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0.14799601, y: 0}

--- a/Assets/Resources/Prefabs/UI/Scene/UI_Game_Root.prefab
+++ b/Assets/Resources/Prefabs/UI/Scene/UI_Game_Root.prefab
@@ -5387,6 +5387,10 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 8865920854715675375}
+    - target: {fileID: 1723190370499489313, guid: 1fd486b46ca5d4e629608d858ac510bb, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1731228031575233836, guid: 1fd486b46ca5d4e629608d858ac510bb, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
       value: 3
@@ -5755,6 +5759,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6537676193336801370, guid: 1fd486b46ca5d4e629608d858ac510bb, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6637363935636966100, guid: 1fd486b46ca5d4e629608d858ac510bb, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -5847,9 +5855,13 @@ PrefabInstance:
     m_RemovedGameObjects:
     - {fileID: 904006170165973393, guid: 1fd486b46ca5d4e629608d858ac510bb, type: 3}
     - {fileID: 6041429416166245133, guid: 1fd486b46ca5d4e629608d858ac510bb, type: 3}
+    - {fileID: 4028015223303204225, guid: 1fd486b46ca5d4e629608d858ac510bb, type: 3}
+    - {fileID: 5568799866212876188, guid: 1fd486b46ca5d4e629608d858ac510bb, type: 3}
+    - {fileID: 1723190370499489313, guid: 1fd486b46ca5d4e629608d858ac510bb, type: 3}
+    - {fileID: 6537676193336801370, guid: 1fd486b46ca5d4e629608d858ac510bb, type: 3}
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 1092776484796498950, guid: 1fd486b46ca5d4e629608d858ac510bb, type: 3}
-      insertIndex: 9
+      insertIndex: 5
       addedObject: {fileID: 4071888742705556573}
     - targetCorrespondingSourceObject: {fileID: 1092776484796498950, guid: 1fd486b46ca5d4e629608d858ac510bb, type: 3}
       insertIndex: -1

--- a/Assets/Scenes/1-1 tutorial.unity
+++ b/Assets/Scenes/1-1 tutorial.unity
@@ -4687,11 +4687,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2520970358692504815, guid: 6c4f3d4828c3e41fdb4978368a0d21d7, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -121.30046
+      value: -116.82
       objectReference: {fileID: 0}
     - target: {fileID: 2520970358692504815, guid: 6c4f3d4828c3e41fdb4978368a0d21d7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -19.303528
+      value: -17.9
       objectReference: {fileID: 0}
     - target: {fileID: 2520970358692504815, guid: 6c4f3d4828c3e41fdb4978368a0d21d7, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4724,14 +4724,6 @@ PrefabInstance:
     - target: {fileID: 2520970358692504815, guid: 6c4f3d4828c3e41fdb4978368a0d21d7, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6614612098860732944, guid: 6c4f3d4828c3e41fdb4978368a0d21d7, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 5.6
-      objectReference: {fileID: 0}
-    - target: {fileID: 6614612098860732944, guid: 6c4f3d4828c3e41fdb4978368a0d21d7, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -14444,6 +14436,14 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3182346297171968216, guid: 59a9ebde221b047c38db217e49c37f57, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3182346297171968216, guid: 59a9ebde221b047c38db217e49c37f57, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3302241564261941427, guid: 59a9ebde221b047c38db217e49c37f57, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -14491,10 +14491,6 @@ PrefabInstance:
     - target: {fileID: 4870807934051463396, guid: 59a9ebde221b047c38db217e49c37f57, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5072110050546012083, guid: 59a9ebde221b047c38db217e49c37f57, type: 3}
-      propertyPath: PlayerDataManager
-      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 5256627909914273373, guid: 59a9ebde221b047c38db217e49c37f57, type: 3}
       propertyPath: m_AnchorMax.x
@@ -15110,11 +15106,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2520970358692504815, guid: 6c4f3d4828c3e41fdb4978368a0d21d7, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -125.61731
+      value: -130.53
       objectReference: {fileID: 0}
     - target: {fileID: 2520970358692504815, guid: 6c4f3d4828c3e41fdb4978368a0d21d7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -19.084028
+      value: -18.41
       objectReference: {fileID: 0}
     - target: {fileID: 2520970358692504815, guid: 6c4f3d4828c3e41fdb4978368a0d21d7, type: 3}
       propertyPath: m_LocalPosition.z
@@ -15147,14 +15143,6 @@ PrefabInstance:
     - target: {fileID: 2520970358692504815, guid: 6c4f3d4828c3e41fdb4978368a0d21d7, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6614612098860732944, guid: 6c4f3d4828c3e41fdb4978368a0d21d7, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -7.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6614612098860732944, guid: 6c4f3d4828c3e41fdb4978368a0d21d7, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/Data/InventoryData.cs
+++ b/Assets/Scripts/Data/InventoryData.cs
@@ -8,6 +8,20 @@ using Newtonsoft.Json.Converters;
 public class InventoryData
 {
     [JsonConverter(typeof(DictionaryEnumKeyConverter<Define.Item, int>))]
-    public Dictionary<Define.Item, int> items;
+    public Dictionary<Define.Item, int> items = new Dictionary<Define.Item, int>();
+    
+    
+    /* '=' 으로 할당시 새로운 인스턴스로 복사하는 것이 아니라 기존 객체를 참조 : 얕은 복사
+     * 따라서 의도한'복사'를 구현하기 위해선 DeepCopy(깊은 복사)를 사용해야함.
+     * 기본적으로 new Dictiaonary<>()를 생성해서 복사해야하며, 코드의 재사용성이 높기 때문에 InventoryData에 직접 깊은 복사 기능을 추가한다.*/
+    public InventoryData DeepCopy()
+    {
+        return new InventoryData
+        {
+            items = new Dictionary<Define.Item, int>(this.items)
+        };
+
+
+    }
     
 }

--- a/Assets/Scripts/Items/ItemBase.cs
+++ b/Assets/Scripts/Items/ItemBase.cs
@@ -46,6 +46,7 @@ public abstract class ItemBase : MonoBehaviour
     {
         if (allowCollect && collision.CompareTag("Player"))
         {
+            Debug.Log(itemType.ToString());
             UpdateCollision(collision.transform);
             Managers.Inventory.InventoryItem(itemType, 1);
             Destroy(gameObject);

--- a/Assets/Scripts/Managers/InventoryManager.cs
+++ b/Assets/Scripts/Managers/InventoryManager.cs
@@ -21,7 +21,7 @@ public class InventoryManager
         //초기화
         Debug.Log("InventoryManager 초기화!");
 
-        currentInventory = Managers.Game.GameInventory;
+        currentInventory = Managers.Game.GameInventory.DeepCopy();
         
         
         _isInitialized = true;
@@ -84,7 +84,7 @@ public class InventoryManager
     public void CommitInventoryState()
     {
         Debug.Log("InventoryManager: 최종 Inventory 상태 저장을 요청합니다");
-        Managers.Game.GameInventory = currentInventory;
+        Managers.Game.GameInventory = currentInventory.DeepCopy();
 
 
     }
@@ -93,7 +93,7 @@ public class InventoryManager
     {
         Debug.Log("InventoryManager : Inventory 상태를 복구합니다. 이전 데이터를 가져와 덮어씁니다.");
 
-        currentInventory = Managers.Game.GameInventory;
+        currentInventory = Managers.Game.GameInventory.DeepCopy();
         Debug.Log($"{currentInventory.items[Define.Item.hpPotionSmall]}, {Managers.Game.GameInventory.items[Define.Item.hpPotionSmall]}");
     }
 

--- a/Assets/Scripts/Managers/InventoryManager.cs
+++ b/Assets/Scripts/Managers/InventoryManager.cs
@@ -22,7 +22,6 @@ public class InventoryManager
         Debug.Log("InventoryManager 초기화!");
 
         currentInventory = Managers.Game.GameInventory;
-        Debug.Log(currentInventory.items[Define.Item.hpPotionSmall]);
         
         
         _isInitialized = true;
@@ -36,7 +35,7 @@ public class InventoryManager
     {
         if (!currentInventory.items.ContainsKey(itemType))
         {
-            Debug.LogWarning($"Unknown item type: {itemType.ToString()}");
+            Debug.LogWarning($"Unknown item type: {itemType.ToString()}"); //장풍 레벨업 토큰이면 log warning 떠도 무시해도 됩니다. 게임 진행에 영향을 미치지 않습니다.
             return;
         }
 
@@ -95,7 +94,7 @@ public class InventoryManager
         Debug.Log("InventoryManager : Inventory 상태를 복구합니다. 이전 데이터를 가져와 덮어씁니다.");
 
         currentInventory = Managers.Game.GameInventory;
-
+        Debug.Log($"{currentInventory.items[Define.Item.hpPotionSmall]}, {Managers.Game.GameInventory.items[Define.Item.hpPotionSmall]}");
     }
 
     #endregion

--- a/Assets/Scripts/Monsters/Monster.cs
+++ b/Assets/Scripts/Monsters/Monster.cs
@@ -268,7 +268,7 @@ public class Monster : MonoBehaviour
         }
         else if (Physics2D.Raycast(transform.position, direction, 1.5f, LayerMask.GetMask("Level1")))
         {
-            Debug.Log("점프 가능");
+            //Debug.Log("점프 가능");
             return 1;
         }
         else

--- a/Assets/Scripts/UI/Buttons/UI_GameOverButtons.cs
+++ b/Assets/Scripts/UI/Buttons/UI_GameOverButtons.cs
@@ -14,6 +14,7 @@ public class UI_GameOverButtons : MonoBehaviour
     {
         exitButton.onClick.AddListener(Exit);
         restartButton.onClick.AddListener(Restart);
+        movement = Managers.PlayerData.GetComponent<NewPlayerMovement>();
     }
 
     public void Exit()
@@ -24,6 +25,7 @@ public class UI_GameOverButtons : MonoBehaviour
     public void Restart()
     {
         movement.OnButtonClick_Restart();
+        Managers.Inventory.RestoreInventoryState();
         Managers.Scene.LoadScene();
     }
 }

--- a/Assets/Scripts/UI/Inventory/InventoryUI.cs
+++ b/Assets/Scripts/UI/Inventory/InventoryUI.cs
@@ -11,12 +11,6 @@ public class InventoryUI : MonoBehaviour
     //배열로 자료구조 변경
     [SerializeField, Tooltip("hpSmall, hpLarge, mpSmall, mpLarge, invisibility 순으로 아이템 개수를 표시하는 TMP_Text UI 오브젝트를 넣어주세요.")] public TMP_Text[] UI_itemTexts; 
     
-    
-    [SerializeField] public TMP_Text hpPotion_Small;
-    [SerializeField] public TMP_Text hpPotion_Large;
-    [SerializeField] public TMP_Text mpPotion_Small;
-    [SerializeField] public TMP_Text mpPotion_Large;
-    [SerializeField] public TMP_Text invisibilityPotion;
 
     public PlayerDataManager PlayerDataManager;
 
@@ -40,6 +34,7 @@ public class InventoryUI : MonoBehaviour
         }
 
         // 초기화 완료 후 이벤트 연결 및 UI 업데이트
+        Managers.Inventory.OnInventoryUpdated -= UpdateItemCntTextUI;
         Managers.Inventory.OnInventoryUpdated += UpdateItemCntTextUI;
         UpdateItemCntTextUI(); // 초기 아이템 개수 표시
     }
@@ -103,7 +98,6 @@ public class InventoryUI : MonoBehaviour
             Debug.LogError("아이템 개수를 표시하는 UI 텍스트 배열이 비어있거나 초기화되지 않았습니다.");
             return;
         }
-
         for (int i = 0; i < itemCnts.Length && i < UI_itemTexts.Length; i++)
         {
             UI_itemTexts[i].text = "x" + itemCnts[i];


### PR DESCRIPTION
### 📌 주요 변경 사항:
- **MPpotionLarge 아이템이 획득되지 않는 문제 수정**
  - MPpotionLarge 프리팹의 `isTrigger`가 체크 해제되어 충돌 감지가 되지 않던 문제 해결
  - `isTrigger`를 활성화하여 정상적으로 아이템 획득 및 인벤토리 반영 확인

- **Inventory 데이터 복구 오류 해결 (참조 타입 문제로 인한 동기화 버그)**
  - InventoryData 객체가 참조 타입이라 발생한 데이터 동기화 문제 해결
  - InventoryData 클래스에 `DeepCopy()` 메서드를 추가하여 깊은 복사 수행
  - InventoryManager에서 GameManager의 InventoryData를 참조하는 대신, `DeepCopy()`를 사용해 독립적인 데이터 관리
  - `"다시하기"` 선택 시, GameManager의 원본 데이터를 사용하여 InventoryManager의 상태를 올바르게 복원하도록 수정

### 🔗 관련 Pull Request
#53(Inventory 저장 구현 관련 PR)의 버그 수정 및 개선을 포함합니다.