### PR TITLE
설정창 키 초기화 기능 추가 및 Intro 아이템 로컬 저장 오류 수정

### DIFF
--- a/.idea/.idea.JangPoong/.idea/workspace.xml
+++ b/.idea/.idea.JangPoong/.idea/workspace.xml
@@ -6,8 +6,13 @@
   <component name="ChangeListManager">
     <list default="true" id="8d60103f-3d9b-4716-9d1c-3d51d042b424" name="변경" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/.idea.JangPoong/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.JangPoong/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Data/InventoryData.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Data/InventoryData.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Managers/InventoryManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Managers/InventoryManager.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Resources/Prefabs/UI/Scene/Setting_UI.prefab" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Resources/Prefabs/UI/Scene/Setting_UI.prefab" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Managers/GameManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Managers/GameManager.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Managers/KeyBindingManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Managers/KeyBindingManager.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Managers/Managers.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Managers/Managers.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Managers/SoundManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Managers/SoundManager.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Sounds/AudioMixerController.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Sounds/AudioMixerController.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/UI/KeyBinding/UI_Setting_KeyCode.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/UI/KeyBinding/UI_Setting_KeyCode.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/.idea/.idea.JangPoong/.idea/workspace.xml
+++ b/.idea/.idea.JangPoong/.idea/workspace.xml
@@ -6,13 +6,6 @@
   <component name="ChangeListManager">
     <list default="true" id="8d60103f-3d9b-4716-9d1c-3d51d042b424" name="변경" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/.idea.JangPoong/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.JangPoong/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Resources/Prefabs/UI/Scene/Setting_UI.prefab" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Resources/Prefabs/UI/Scene/Setting_UI.prefab" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Managers/GameManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Managers/GameManager.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Managers/KeyBindingManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Managers/KeyBindingManager.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Managers/Managers.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Managers/Managers.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Managers/SoundManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Managers/SoundManager.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Sounds/AudioMixerController.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Sounds/AudioMixerController.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/UI/KeyBinding/UI_Setting_KeyCode.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/UI/KeyBinding/UI_Setting_KeyCode.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/Assets/Resources/Prefabs/UI/Scene/Setting_UI.prefab
+++ b/Assets/Resources/Prefabs/UI/Scene/Setting_UI.prefab
@@ -146,13 +146,14 @@ GameObject:
   - component: {fileID: 6519683923450950620}
   - component: {fileID: 3543672056372575042}
   - component: {fileID: 5074192137475140959}
+  - component: {fileID: 1107016557569213302}
   m_Layer: 5
-  m_Name: Testbtn
+  m_Name: UI_Button_KeyReset
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &8733390101167351645
 RectTransform:
   m_ObjectHideFlags: 0
@@ -170,8 +171,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 282, y: -327}
-  m_SizeDelta: {x: 120, y: 60}
+  m_AnchoredPosition: {x: 261, y: -327}
+  m_SizeDelta: {x: 160, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6519683923450950620
 CanvasRenderer:
@@ -254,19 +255,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 3543672056372575042}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: KeyBindingUIManager, Assembly-CSharp
-        m_MethodName: OnButtonClick
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
+--- !u!114 &1107016557569213302
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1339831675636211321}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6a6816e59f6e547b88834dd771bf6a2f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1928818222614085873
 GameObject:
   m_ObjectHideFlags: 0
@@ -1333,7 +1334,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "\uD14C\uC2A4\uD2B8"
+  m_text: "\uD0A4 \uCD08\uAE30\uD654"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: bd73df3feaeda4dac89ca6c112308298, type: 2}
   m_sharedMaterial: {fileID: 2187095669032760298, guid: bd73df3feaeda4dac89ca6c112308298, type: 2}
@@ -2916,9 +2917,9 @@ RectTransform:
   m_Children:
   - {fileID: 3270185875576025425}
   - {fileID: 2431854416952383040}
+  - {fileID: 8733390101167351645}
   - {fileID: 8380221844008585259}
   - {fileID: 6491833546614629316}
-  - {fileID: 8733390101167351645}
   - {fileID: 8839335723544387421}
   m_Father: {fileID: 2633488161862176517}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -6,31 +6,47 @@ using Newtonsoft.Json;
 
 public class GameManager
 {
-    private bool isInit = false;
-    public bool IsInit
+    // private bool isInit = false;
+    // public bool IsInit
+    // {
+    //     get => isInit;
+    // }
+    
+    
+    private SettingData _setting;
+    private InventoryData _gameInventory;
+
+
+    public SettingData Setting
     {
-        get => isInit;
+        get
+        {
+            if (_setting == null)
+            {
+                LoadData(Define.SaveKey.SettingData, out _setting);
+            }
+
+            return _setting;
+        }
     }
-    public SettingData _settingData;
-    private InventoryData gameInventory;
     
     public InventoryData GameInventory
     {
         get
         {
-            if (gameInventory == null)
+            if (_gameInventory == null)
             {
-                LoadData(Define.SaveKey.InventoryData, out gameInventory);
+                LoadData(Define.SaveKey.InventoryData, out _gameInventory);
             }
 
-            return gameInventory;
+            return _gameInventory;
         }
 
         set
         {
             Debug.Log("GameManager : Inventory 상태 업데이트 후 로컬 저장 요청");
-            gameInventory = value;
-            Managers.Data.SaveData(Define.SaveKey.InventoryData, gameInventory);
+            _gameInventory = value;
+            Managers.Data.SaveData(Define.SaveKey.InventoryData, _gameInventory);
         }
     }
     
@@ -38,26 +54,19 @@ public class GameManager
     // public PlayerData playerData;
     // public ProgressData progressData;
     // public StatisticData statisticData;
+
     
-    
-    //초기화 완료 이벤트
-    public event Action OnDataLoaded;
-    
-    
-    //Setting Data 불러오기
-    //
     public void Init()
     {
         
         Debug.Log("GameManager Init 호출");
-        LoadData(Define.SaveKey.SettingData, out _settingData);
         
-        isInit = true;
+        // isInit = true;
         
-        Debug.Log($"GameManager.Init called. OnInitialized is {(OnDataLoaded == null ? "null" : "not null")}");
+        // Debug.Log($"GameManager.Init called. OnInitialized is {(OnDataLoaded == null ? "null" : "not null")}");
         //데이터 읽어와서 초기화 완료됐음을 알림
-        OnDataLoaded?.Invoke();
-        Debug.Log("GameManager: Data loaded and OnDataLoaded invoked.");
+        // OnDataLoaded?.Invoke();
+        // Debug.Log("GameManager: Data loaded and OnDataLoaded invoked.");
         
 
     }

--- a/Assets/Scripts/Managers/Managers.cs
+++ b/Assets/Scripts/Managers/Managers.cs
@@ -45,7 +45,15 @@ public class Managers : MonoBehaviour
     public static UIManager UI { get { return Instance._ui; } }
     public static SoundManager Sound
     {
-        get { return Instance._sound; }
+        get
+        {
+            if (Instance._sound == null)
+            {
+                Instance._sound = new SoundManager(); //처음 접근할 때 생성하고 초기화한다.
+                Instance._sound.Init();
+            }
+            return Instance._sound;
+        }
     }
 
     public static PlayerDataManager PlayerData
@@ -66,6 +74,11 @@ public class Managers : MonoBehaviour
     {
         get
         {
+            if (Instance._keyBind == null)
+            {
+                Instance._keyBind = new KeyBindingManager(); //처음 접근할 때 생성하고 초기화한다.
+                //Instance._keyBind.
+            }
             return Instance._keyBind;
         }
     }
@@ -119,10 +132,7 @@ public class Managers : MonoBehaviour
             
             
             s_instance._sound.Init();
-            //s_instance._inventory.Init();
-            //s_instance._keyBind.LoadKeyBinding();
-            
-            
+
             
             _isInitialized = true; // 초기화 완료
             

--- a/Assets/Scripts/Managers/SoundManager.cs
+++ b/Assets/Scripts/Managers/SoundManager.cs
@@ -29,11 +29,8 @@ public class SoundManager
          //Sound 초기화 부분 GameManager로 이동. GameManager에서 Setting 데이터 처리하도록 수정 (250116)
          
          //사운드 셋팅 적용
-         if (Managers.Game._settingData != null)
-         {
-            SetBgmVolume(Managers.Game._settingData.audioVolume.Bgm);
-            SetSfxVolume(Managers.Game._settingData.audioVolume.Sfx);
-         }
+         SetBgmVolume(Managers.Game.Setting.audioVolume.Bgm);
+         SetSfxVolume(Managers.Game.Setting.audioVolume.Sfx);
         
       }
       
@@ -67,14 +64,14 @@ public class SoundManager
    
    public void SetBgmVolume(float volume)
    {
-      Managers.Game._settingData.audioVolume.Bgm = volume; //json으로 데이터 저장 변경
+      Managers.Game.Setting.audioVolume.Bgm = volume; //json으로 데이터 저장 변경
       float bgmVolume = Mathf.Log10(volume) * 20;
       audioMixer.SetFloat("BGM", bgmVolume);
    }
 
    public void SetSfxVolume(float volume)
    {
-      Managers.Game._settingData.audioVolume.Sfx = volume; //json으로 데이터 저장 변경
+      Managers.Game.Setting.audioVolume.Sfx = volume; //json으로 데이터 저장 변경
       float sfxVolume = Mathf.Log10(volume) * 20;
       audioMixer.SetFloat("SFX", sfxVolume);
    }

--- a/Assets/Scripts/Sounds/AudioMixerController.cs
+++ b/Assets/Scripts/Sounds/AudioMixerController.cs
@@ -19,8 +19,8 @@ public class AudioMixerController : MonoBehaviour
     {
         audioMixer = Managers.Sound.audioMixer;
 
-        bgmSlider.value = Managers.Game._settingData.audioVolume.Bgm;
-        sfxSlider.value = Managers.Game._settingData.audioVolume.Sfx;
+        bgmSlider.value = Managers.Game.Setting.audioVolume.Bgm;
+        sfxSlider.value = Managers.Game.Setting.audioVolume.Sfx;
             
         bgmSlider.onValueChanged.RemoveAllListeners();
         sfxSlider.onValueChanged.RemoveAllListeners();
@@ -31,10 +31,10 @@ public class AudioMixerController : MonoBehaviour
     private void SetBgmVolume (float volume)
     { 
         Debug.Log("슬라이드 값 변경에 따른 이벤트 호출");
-        if (Mathf.Abs(volume - Managers.Game._settingData.audioVolume.Bgm) > epsilon)
+        if (Mathf.Abs(volume - Managers.Game.Setting.audioVolume.Bgm) > epsilon)
         {
             Managers.Sound.SetBgmVolume(volume);
-            Managers.Data.SaveData(Define.SaveKey.SettingData, Managers.Game._settingData);
+            Managers.Data.SaveData(Define.SaveKey.SettingData, Managers.Game.Setting);
         }
             
     }
@@ -42,10 +42,10 @@ public class AudioMixerController : MonoBehaviour
     private void SetSfxVolume(float volume)
     {
         
-        if (Mathf.Abs(volume - Managers.Game._settingData.audioVolume.Sfx) > epsilon)
+        if (Mathf.Abs(volume - Managers.Game.Setting.audioVolume.Sfx) > epsilon)
         {
             Managers.Sound.SetSfxVolume(volume);
-            Managers.Data.SaveData(Define.SaveKey.SettingData, Managers.Game._settingData);
+            Managers.Data.SaveData(Define.SaveKey.SettingData, Managers.Game.Setting);
         }
             
     }

--- a/Assets/Scripts/Stage/Intro.cs
+++ b/Assets/Scripts/Stage/Intro.cs
@@ -267,10 +267,14 @@ public class Intro : MonoBehaviour
         // Managers.Inventory.hpLargeCnt += 1;
         // Managers.Inventory.mpSmallCnt += 1;
         // Managers.Inventory.mpLargeCnt += 1;
+        
+        //인벤토리에 아이템 추가
         for (int i = 0; i < (int)Define.Item.levelUpToken; i++)
         {
             Managers.Inventory.InventoryItem((Define.Item)i,1);
         }
+        //씬 이동 전에 인벤토리 데이터 저장되도록 처리 : GameManager로 커밋한다.
+        Managers.Inventory.CommitInventoryState();
 
         // Scene 전환
         SceneManager.LoadScene("0-1 tutorial");

--- a/Assets/Scripts/UI/KeyBinding/UI_Button_KeyReset.cs
+++ b/Assets/Scripts/UI/KeyBinding/UI_Button_KeyReset.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class UI_Button_KeyReset : MonoBehaviour
+{
+    private Button keyRestBtn;
+    
+    // Start is called before the first frame update
+    void Start()
+    {
+        keyRestBtn = GetComponent<Button>();
+        keyRestBtn.onClick.RemoveAllListeners();
+        keyRestBtn.onClick.AddListener(ResetKeyBinding);
+        
+    }
+
+    private void ResetKeyBinding()
+    {
+        Managers.KeyBind.ResetKeyBinding();
+    }
+
+    
+}

--- a/Assets/Scripts/UI/KeyBinding/UI_Button_KeyReset.cs.meta
+++ b/Assets/Scripts/UI/KeyBinding/UI_Button_KeyReset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a6816e59f6e547b88834dd771bf6a2f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/KeyBinding/UI_Setting_KeyCode.cs
+++ b/Assets/Scripts/UI/KeyBinding/UI_Setting_KeyCode.cs
@@ -37,19 +37,27 @@ public class UI_Setting_KeyCode : MonoBehaviour
 
     }
 
-    private void OnEnable()
+    private void Start()
     {
-        if (Managers.Game != null)
-        {
-            // 이벤트 구독
-            Managers.Game.OnDataLoaded += Init;
+        StartCoroutine(WaitForManagersInitialization());
+    }
 
-            // GameManager가 이미 초기화된 상태라면 바로 초기화
-            if (Managers.Game.IsInit)
-            {
-                Init();
-            }
+    private IEnumerator WaitForManagersInitialization()
+    {
+        // Managers 초기화 대기
+        while (!Managers.IsInitialized)
+        {
+            yield return null; // 다음 프레임까지 대기
         }
+        
+        
+        //Managers 초기화 완료 후 UI 초기화 진행
+        Init();
+        //이벤트 구독
+        Managers.KeyBind.OnResetKeyBinding -= Init;
+        Managers.KeyBind.OnResetKeyBinding += Init;
+        
+
     }
 
     private void Init()


### PR DESCRIPTION
**Feat: 설정창 키 초기화 기능 추가**

- 설정창에 키 초기화 버튼 UI 추가 및 기능 구현
- 클릭 시 KeyBindManager에서 키 컨트롤 데이터 초기화
- SettingData.json을 읽어와 로컬 저장 키 설정 덮어쓰기
- 초기화 후 설정창 UI 업데이트 (이벤트 핸들러 활용)

**Fix: Intro에서 획득한 아이템이 로컬 저장소에 저장되지 않는 오류 수정**
- Intro 진행 후 아이템 획득 데이터가 인벤토리에 반영되지만, 로컬 저장이 되지 않는 문제 해결